### PR TITLE
Fixed editing behavior so no errors are thrown

### DIFF
--- a/app/controllers/task.js
+++ b/app/controllers/task.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.ObjectController.extend({
   
   isEditing: false,
+  newTitle: Ember.computed.oneWay('title'),
   
   isCompleted: function(key, value){
     var model = this.get('model');
@@ -24,17 +25,31 @@ export default Ember.ObjectController.extend({
     },
 
     delete: function () {
-      this.get('model').destroyRecord();
+      this.delete();
     },
 
     acceptChanges: function () {
-      this.set('isEditing', false);
+      var newTitle = this.get('newTitle').trim();
 
-      if (Ember.isEmpty(this.get('model.title'))) {
-        this.send('delete', task);
+      if (Ember.isEmpty(newTitle)) {
+        Ember.run.debounce(this, 'delete', 0);
       } else {
-        this.get('model').save();
+        var task = this.get('model');
+        task.set('title', newTitle);
+        task.save();
       }
+      
+      this.set('newTitle', newTitle);
+      this.set('isEditing', false);
     },
+    
+    discardChanges: function () {
+      this.set('newTitle', this.get('title'));
+      this.set('isEditing', false);
+    }
+  },
+  
+  delete: function () {
+    return this.get('model').destroyRecord();
   }
 });

--- a/app/templates/tasks/index.hbs
+++ b/app/templates/tasks/index.hbs
@@ -2,7 +2,7 @@
   {{#each task in model itemController='task'}}
   <li {{bind-attr class="task.isCompleted:complete task.isEditing:editing" }}>
     {{#if task.isEditing}}
-      {{input class="edit" value=task.title focus-out="acceptChanges" insert-newline="acceptChanges" autofocus="autofocus"}}
+      {{input class="edit" value=task.newTitle focus-out="acceptChanges" insert-newline="acceptChanges" escape-press="discardChanges" autofocus="autofocus"}}
     {{else}}
       {{input type="checkbox" checked=task.isCompleted class="toggle"}}
       <label {{action 'edit' on='doubleClick'}}>{{task.title}}</label>


### PR DESCRIPTION
Resolves #30 

The issue was with deleting the task when it's title is empty. The action get's called twice, so `model.save` is also called twice. Using a debounced call avoids this issue. Additionally, escape now cancels pending changes instead of saving them.
