### PR TITLE
Updated ember to 1.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-gdrive-todo-mvc",
   "dependencies": {
-    "handlebars": "~1.3.0",
+    "handlebars": "~2.0.0",
     "jquery": "^1.11.1",
-    "ember": "1.8.1",
-    "ember-data": "1.0.0-beta.12",
+    "ember": "components/ember#1.9.0",
+    "ember-data": "components/ember-data#1.0.0-beta.14.1",
     "ember-resolver": "~0.1.11",
     "loader.js": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "ember-cli": "^0.1.7",
     "ember-cli-6to5": "0.2.1",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
+    "ember-cli-htmlbars": "^0.5.3",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.2",


### PR DESCRIPTION
Resolves #47, resolves #46 

Involves several other dependencies
- ember-data to 1.0.0-beta.14.1
- handlebars to ^2.0.0
- broccoli-ember-hbs-template-compiler#^1.6.1 replaced with ember-cli-htmlbars#^0.5.3
